### PR TITLE
把某个人写的语法错误改掉

### DIFF
--- a/kubejs/startup_scripts/src/GT/GTmaterials.js
+++ b/kubejs/startup_scripts/src/GT/GTmaterials.js
@@ -1402,7 +1402,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
     event.create("aluminium_chloride")
         .dust()
         .color(0x045681)
-    event.create("titanium_tetrachloride_V")
+    event.create("titanium_tetrachloride_v")
         .liquid()
         .color(0x024789)
     event.create("tungsten_trioxide")


### PR DESCRIPTION
有人把event.create("titanium_tetrachloride_v")的“v"写成了大写